### PR TITLE
Handle non-numeric versions strings from *IDN?

### DIFF
--- a/oscope_scpi/scpi.py
+++ b/oscope_scpi/scpi.py
@@ -411,8 +411,13 @@ class SCPI(object):
         self._IDNserial = idn[2] # store instrument serial number from IDN here
 
         ver = idn[3].split('.')
-        # put major and minor version into floating point format so can numerically compare
-        self._version = float(ver[0]+'.'+ver[1])
+        try:
+            # put major and minor version into floating point format so can numerically compare
+            self._version = float(ver[0]+'.'+ver[1])
+        except:
+            # In case version is not purely numeric
+            self._version = tuple(ver)
+            self._versionLegacy = tuple()
         
     def idn(self):
         """Return response to *IDN? message"""

--- a/oscope_scpi/scpi.py
+++ b/oscope_scpi/scpi.py
@@ -416,6 +416,7 @@ class SCPI(object):
             self._version = float(ver[0]+'.'+ver[1])
         except:
             # In case version is not purely numeric
+            ver[-1] = ver[-1].replace('\n', '')
             self._version = tuple(ver)
             self._versionLegacy = tuple()
         


### PR DESCRIPTION
Not all instruments return numerical strings.
By handling exceptions when converting the version string to a float number, we can fallback into storing the version into a tuple, that also handles version comparison.
It also requires to set `_versionLegacy` into an empty tuple, so that comparison can take place.

I needed this specifically for a Keysight N6705B DC Analyzer that reports a firmware version of `D.02.13`
While not technically a scope, there are many useful functions for me in the SCPI module, and as the same app also supports another scope, I preferred using SCPI for this as well.
As the SCPI standard doesn't enforce any format on firmware version numbers, you might find this useful anyhow.
