### PR TITLE
Support DSO#### Scopes

### DIFF
--- a/oscope_scpi/dso.py
+++ b/oscope_scpi/dso.py
@@ -264,3 +264,54 @@ class MSOX3xx4T(MSOX):
         # enough
         self._versionLegacy = 9.999
         
+class DSO(Keysight):
+    """Basic class for controlling and accessing a HP/Agilent/Keysight Generic DSO### Oscilloscope"""
+
+    def __init__(self, resource, model,wait=0):
+        """Init the class with the instrument's resource string
+
+        resource   - resource string or VISA descriptor, like TCPIP0::172.16.2.13::INSTR
+        maxChannel - number of channels of this oscilloscope
+        wait       - float that gives the default number of seconds to wait after sending each command
+        """
+        channels = int(model[-2]) # model number format: DSO####A, last number is channels (suffix letter is revision)
+        super(DSO, self).__init__(resource, maxChannel=channels, wait=wait)
+
+        # Give the Series a name
+        self._series = 'DSO'        
+        
+    def measureStatistics(self):
+        """Returns an array of dictionaries from the current statistics window.
+
+        The definition of the returned dictionary can be easily gleaned
+        from the code below.
+        """
+
+        # turn on the statistics display - these are specific to MSOX/DSOX
+        # self._instWrite("SYSTem:MENU MEASure")
+        self._instWrite("MEASure:STATistics ON")
+
+        statFlat = super(DSO, self)._measureStatistics()
+        
+        # convert the flat list into a two-dimentional matrix with seven columns per row
+        cols = 7
+        if ((len(statFlat) % cols != 0)):
+            print('Unexpected response. Oscilloscope may not have any measurements enabled.')
+            statMat = []
+        else:
+            statMat = [statFlat[i:i+cols] for i in range(0,len(statFlat),cols)]
+        
+        # convert each row into a dictionary, while converting text strings into numbers
+        stats = []
+        for stat in statMat:            
+            stats.append({'label':stat[0],
+                          'CURR':float(stat[1]),   # Current Value
+                          'MIN':float(stat[2]),    # Minimum Value
+                          'MAX':float(stat[3]),    # Maximum Value
+                          'MEAN':float(stat[4]),   # Average/Mean Value
+                          'STDD':float(stat[5]),   # Standard Deviation
+                          'COUN':float(stat[6])    # Count of measurements
+                          })
+
+        # return the result in an array of dictionaries
+        return stats

--- a/oscope_scpi/keysight.py
+++ b/oscope_scpi/keysight.py
@@ -93,6 +93,14 @@ class Keysight(Oscilloscope):
         self._annotationText = ''
         self._annotationColor = 'ch1' # default to Channel 1 color
 
+    def measureStatistics(self):
+        """Returns data from the current statistics window.
+        """
+        # Provide the function definition in case a child class doesn't
+
+        statFlat = self._measureStatistics()
+        return statFlat
+
 
     def modeRun(self):
         """ Set Oscilloscope to RUN Mode """

--- a/oscope_scpi/oscilloscope.py
+++ b/oscope_scpi/oscilloscope.py
@@ -38,6 +38,7 @@ from __future__ import print_function
 
 import sys
 import os
+import re
 
 try:
     from .scpi import SCPI
@@ -226,6 +227,14 @@ class Oscilloscope(SCPI):
                 else:
                     # Generic MSOX
                     newobj = MSOX(self._resource, wait=self._wait)
+            elif re.search('^DSO\d+[A-Z]$',self._IDNmodel.upper()) is not None: # Older DSO models, such as DSO90804A, DSO6054A, DSO7014B
+                try:
+                    from .dso import DSO
+                except Exception:
+                    sys.path.append(os.getcwd())
+                    from dso import DSO
+
+                newobj = DSO(self._resource, model=self._IDNmodel,wait=self._wait)
             else:
                 try:
                     from .keysight import Keysight


### PR DESCRIPTION
The DSO#### family of scopes maps to a generic Keysight scope. This expands support to include them as well.

# Changes

- add a new class in `dso.py` called DSO (inherits directly from Keysight)
  - get max channels from the model number
- add `measureStatistics` function for class
- match model number using regular expressions in `oscilloscope.py` after DSO-* matches
- define `measureStatistics` in `Keysight` class

## DSO Model Numbers

The model numbers for these devices are as follows:

| Field | Prefix | Series | Bandwidth | Channels | Revision |
| --- | --- | --- | --- | --- | --- |
| Width | 3 | no limit | 2 | 1 | 1 |
| Example | DSO | 90 | 80 | 4 | A |

The DSO90804A example scope is of the 90000 series, samples at 80 GS/s, and has 4 channels. Most Keysights are revision A, but I've seen some revision Bs.

## measureStatistics Function

Without the new `measureStatistics` function, several scope families won't have this function defined at all (generic scopes, EXR, etc). At the bare minimum, we can return the raw object from the scope. Currently the example function in `README.md` fails for those scopes.

# Testing

Tested on a DSO90804A scope.