### PR TITLE
WaveformData Fixes

### DIFF
--- a/oscope_scpi/keysight.py
+++ b/oscope_scpi/keysight.py
@@ -303,8 +303,6 @@ class Keysight(Oscilloscope):
         # Create array for meta data
         meta = []
         
-        # Set the waveform source.
-        self._instWrite("WAVeform:SOURce {}".format(self.channelStr(channel)))
         wav_source = self._instQuery("WAVeform:SOURce?")
 
         # Get the waveform view.
@@ -603,8 +601,6 @@ class Keysight(Oscilloscope):
         # Create array for meta data
         meta = []
 
-        # Set the waveform source.
-        self._instWrite("WAVeform:SOURce {}".format(self.channelStr(channel)))
         wav_source = self._instQuery("WAVeform:SOURce?")
 
         # Get the waveform view.
@@ -770,7 +766,7 @@ class Keysight(Oscilloscope):
     def waveformData(self, channel=None, points=None):
         """ Download waveform data of a selected channel
 
-        channel  - channel, as string, to be measured - set to None to use the default channel
+        channel  - channel to be measured - set to None to use the default channel
 
         points   - number of points to capture - if None, captures all available points
                    for newer devices, the captured points are centered around the center of the display
@@ -786,18 +782,23 @@ class Keysight(Oscilloscope):
         if type(self.channel) is list or type(channel) is list:
             raise ValueError('Channel cannot be a list for WAVEFORM!')
 
+        chan_str = self.channelStr(self.channel)
         # Check channel value
-        if (self.channel not in self.chanAllValidList):
-            raise ValueError('INVALID Channel Value for WAVEFORM: {}  SKIPPING!'.format(self.channel))            
+        if (chan_str not in self.chanAllValidList):
+            raise ValueError('INVALID Channel Value for WAVEFORM: {}  SKIPPING!'.format(chan_str))
+
+        # Set the waveform source.
+        self._instWrite("WAVeform:SOURce {}".format(chan_str))
+
         # Check for data
         complete = int(self._instQuery('WAV:COMP?')) # get percent complete
         if complete == 0:
             raise BufferError('No waveform data')
         
         if (self._version > self._versionLegacy):
-            (x, y, header, meta) = self._waveformDataNew(self.channel, points)
+            (x, y, header, meta) = self._waveformDataNew(chan_str, points)
         else:
-            (x, y, header, meta) = self._waveformDataLegacy(self.channel, points)        
+            (x, y, header, meta) = self._waveformDataLegacy(chan_str, points)
 
         return (x, y, header, meta)
         

--- a/oscope_scpi/keysight.py
+++ b/oscope_scpi/keysight.py
@@ -791,7 +791,7 @@ class Keysight(Oscilloscope):
         self._instWrite("WAVeform:SOURce {}".format(chan_str))
 
         # Check for data
-        complete = int(self._instQuery('WAV:COMP?')) # get percent complete
+        complete = int(self._instQuery('WAVeform:COMPlete?')) # get percent complete
         if complete == 0:
             raise BufferError('No waveform data')
         

--- a/oscope_scpi/keysight.py
+++ b/oscope_scpi/keysight.py
@@ -789,7 +789,10 @@ class Keysight(Oscilloscope):
         # Check channel value
         if (self.channel not in self.chanAllValidList):
             raise ValueError('INVALID Channel Value for WAVEFORM: {}  SKIPPING!'.format(self.channel))            
-
+        # Check for data
+        complete = int(self._instQuery('WAV:COMP?')) # get percent complete
+        if complete == 0:
+            raise BufferError('No waveform data')
         
         if (self._version > self._versionLegacy):
             (x, y, header, meta) = self._waveformDataNew(self.channel, points)


### PR DESCRIPTION
This fixes two errors in oscope_scpi/keysight.py:waveformData.

# No Waveform Data

If there is no waveform data (scope hasn't been triggered yet, etc), `WAVeform:PREamble?` returns 22 values rather than 24. This causes [the next line](https://github.com/sgoadhouse/oscope-scpi/blob/main/oscope_scpi/keysight.py#L403) to throw an unhelpful error. While the error from the oscope is helpful, a ValueError exception is a mischaracterization of the error, so catching it doesn't make sense. I rewrote it to throw a `BufferError` instead (line 793-796) so it can be more intuitively caught and handled.

```
ERROR(00): 41,"Waveform data is not valid.", command: ':WAVeform:PREamble?'
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "oscope_scpi/oscilloscope.py", line 329, in waveform
    (x, y, header, meta) = self.waveformData(channel, points)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "oscope_scpi/keysight.py", line 799, in waveformData
    (x, y, header, meta) = self._waveformDataNew(chan_str, points)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "oscope_scpi/keysight.py", line 401, in _waveformDataNew
    (wav_form, acq_type, wfmpts, avgcnt, x_increment, x_origin,
ValueError: not enough values to unpack (expected 24, got 22)
```

`oscilloscope.py:waveform` could also be rewritten to just return None or 0 on this error, but I felt preserving the exception provides better control to the user.

# Channel Argument

`waveformData` says it takes channel as a string or None. When None is passed, we use `self.channel`, which isn't necessarily a string. Now it can take either a string or an integer because conversion happens within the function.

I also moved setting the waveform source to `waveformData` and out of the called functions `_waveformDataNew` and `_waveformDataLegacy`. It needs to be in `waveformData` in order to query the waveform completeness (line 794). We could leave setting this in the called functions, but it would be redundant.